### PR TITLE
Pull request Burundi 2012 JW 20210609

### DIFF
--- a/1_antenatal_care.do
+++ b/1_antenatal_care.do
@@ -83,7 +83,13 @@
 	gen c_anc_ur_q = .
 	
 	*c_anc_ir: iron supplements taken during pregnancy of births in last 2 years	
-	gen c_anc_ir = .
+	if inlist(name,"Burundi2012"){
+		gen c_anc_ir = ( inlist(m45,1,2) )
+	    replace c_anc_ir = . if inlist(m45,8,9,.) 
+	}
+	if ~inlist(name, "Burundi2012"){
+		gen c_anc_ir = .
+	}
 	
 	*c_anc_ir_q: iron supplements taken during pregnancy among ANC users of births in last 2 years
 	gen c_anc_ir_q = .

--- a/Quality_control.do
+++ b/Quality_control.do
@@ -102,6 +102,7 @@ keep surveyid ispreferred value*
 keep if _n == 1
 reshape long value_my,i(surveyid ispreferred)j(varname_my) string
 replace value_my = value_my*100 if varname_my != "w_bmi_1549"
+replace surveyid = "BU2012MIS" if surveyid == "BI2012MIS"
 
 merge 1:1 surveyid varname_my ispreferred using "${SOURCE}/external/DHS.dta"
 keep if _merge == 3  //for _merge == 1, missing data to generate the indicator.


### PR DESCRIPTION
- lines added to generate c_anc_ir
- In the case of Burundi2012, the surveyid in the DHS.DTA is "BU2012MIS" but the surveyid generated from iso2c is "BI2012MIS". The surveyid needs to be changed to ensure that two datasets can merge smoothly.